### PR TITLE
Disable wps on WP-CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+- a check that disables the execution if we are running WP-CLI
+
 ## 1.2 - 2018-12-18
 
 ### Added

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -121,11 +121,19 @@ class Plugin extends Container {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function is_wp_cli() {
+
+		return defined( 'WP_CLI' ) && WP_CLI;
+	}
+
+	/**
 	 * Execute run conditionally on debug configuration.
 	 */
 	public function run() {
 
-		if ( ! $this->is_debug() || ! $this->is_debug_display() ) {
+		if ( ! $this->is_debug() || ! $this->is_debug_display() || $this->is_wp_cli() ) {
 			return;
 		}
 


### PR DESCRIPTION
Without this, Whoops catches the errors on CLI execution and they get suppressed completely.