### PR TITLE
Enable Whoops Blocking only when Notices/Warnings come from specific Plugins/Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://poser.pugx.org/rarst/wps/v/stable)](https://packagist.org/packages/rarst/wps)
 [![Total Downloads](https://poser.pugx.org/rarst/wps/downloads)](https://packagist.org/packages/rarst/wps)
 [![PHP version](https://img.shields.io/packagist/php-v/rarst/wps.svg)](https://packagist.org/packages/rarst/wps)
-[![Download wps](https://img.shields.io/badge/dynamic/json.svg?label=download&url=https://api.github.com/repos/rarst/wps/releases/latest&query=$.assets%5B0%5D.name)](https://github.com/Rarst/wps/releases/latest/download/wps.zip)
+[![Download wps](https://img.shields.io/badge/dynamic/json.svg?label=download&url=https://api.github.com/repos/rarst/wps/releases/latest&query=$.assets%5B0%5D.name)](https://www.rarst.net/download/wps)
 
 wps adds [whoops](http://filp.github.io/whoops/) error handler to a WordPress installation. 
 
@@ -13,13 +13,61 @@ It makes error messages from PHP, `admin-ajax.php`, and WP REST API a _great_ de
 
 | [Composer](https://getcomposer.org/) (recommended) | Release archive |  
 | -------------------------------------------------- | -------- |  
-| `composer require rarst/wps` | [![Download wps](https://img.shields.io/badge/dynamic/json.svg?label=download&url=https%3A%2F%2Fapi.github.com%2Frepos%2Frarst%2Fwps%2Freleases%2Flatest&query=%24.assets[0].name&style=for-the-badge)](https://github.com/Rarst/wps/releases/latest/download/wps.zip) |
+| `composer require rarst/wps` | [![Download wps](https://img.shields.io/badge/dynamic/json.svg?label=download&url=https%3A%2F%2Fapi.github.com%2Frepos%2Frarst%2Fwps%2Freleases%2Flatest&query=%24.assets[0].name&style=for-the-badge)](https://www.rarst.net/download/wps) |
 
 ## Usage
 
 The plugin is meant strictly for development and will only work with `WP_DEBUG` and `WP_DEBUG_DISPLAY` configuration constants enabled.
 
-To temporarily disable whoops output you can use `?wps_disable` query argument in the URL. 
+To temporarily disable whoops output you can use `?wps_disable` query argument
+in the URL. 
+
+By default the plugin blocks the execution whenever any kind of
+notice/warning/error/exception occurs. This is really useful when
+site is being built from the scratch, however, this could create a problem 
+when everything is not being built from the scratch — specifically when a notice
+or warning comes from a plugin you did not develop.
+
+This could be solved in one of the four ways.
+
+### Skip Whoops Blocking for all Notices and Warnings
+In `wps.php`, call `skipNoticesAndWarnings()` on `$wps` object. So it
+might look like this
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $wps->skipNoticesAndWarnings();
+  $wps->run();
+```
+
+`skipNoticesAndWarnings` accepts an object of `Rarst\wps\Except` class to
+enable Whoops for notices/warnings of only specified plugins/themes.
+
+### Enable Whoops' Notices/Warnings Blocking for Specific Plugins
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('akismet'));
+  $wps->run();
+```
+Above example will skip all notices and warnings except coming from `akismet`
+plugin. Pass multiple plugins to be excepted as separate arguments.
+
+### Enable Whoops Notices/Warnings Blocking Blocking for Specific Themes
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $wps->skipNoticesAndWarnings(Rarst\wps\Except::themesDirectories('twentytwenty'));
+  $wps->run();
+```
+Above example will skip all notices and warnings except coming from `twentytwenty`
+theme. Pass multiple themes to be excepted as separate arguments.
+
+### Enable Whoops Blocking for Specific Plugins and Themes together
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $excluded_plugins = ['akismet'];
++ $excluded_themes  = ['twentytwenty'];
++ $wps->skipNoticesAndWarnings(new Rarst\wps\Except($excluded_plugins, $excluded_themes));
+  $wps->run();
+``` 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,19 @@ In `wps.php`, call `skipNoticesAndWarnings()` on `$wps` object. So it
 might look like this
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $wps->skipNoticesAndWarnings(Rarst\wps\Except::blank());
++ $wps->skipNoticesAndWarnings(Except::blank());
   $wps->run();
 ```
 
 `skipNoticesAndWarnings` accepts an object of `Rarst\wps\Except` class to
-enable Whoops for notices/warnings of only specified plugins/themes.
+enable Whoops for notices/warnings of only specified plugins/themes. 
+`Except` class accepts array of regex patterns to be excluded from skipping
+notices and warnings.
 
 ### Enable Whoops' Notices/Warnings Blocking for Specific Plugins
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('akismet'));
++ $wps->skipNoticesAndWarnings(Except::pluginsDirectories('akismet'));
   $wps->run();
 ```
 Above example will skip all notices and warnings except coming from `akismet`
@@ -54,7 +56,7 @@ plugin. Pass multiple plugins to be excepted as separate arguments.
 ### Enable Whoops Notices/Warnings Blocking Blocking for Specific Themes
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $wps->skipNoticesAndWarnings(Rarst\wps\Except::themesDirectories('twentytwenty'));
++ $wps->skipNoticesAndWarnings(Except::themesDirectories('twentytwenty'));
   $wps->run();
 ```
 Above example will skip all notices and warnings except coming from `twentytwenty`
@@ -63,9 +65,8 @@ theme. Pass multiple themes to be excepted as separate arguments.
 ### Enable Whoops Blocking for Specific Plugins and Themes together
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $excluded_plugins = ['akismet'];
-+ $excluded_themes  = ['twentytwenty'];
-+ $wps->skipNoticesAndWarnings(new Rarst\wps\Except($excluded_plugins, $excluded_themes));
++ $exceptions = ['@plugins/akismet@', '@themes/twentytwenty@'];
++ $wps->skipNoticesAndWarnings(new Except($exceptions));
   $wps->run();
 ``` 
 ### Silent Errors using Regex
@@ -90,7 +91,7 @@ is inside the plugin, then you might write something like this in
 wps.php.
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('plugin-folder'));
++ $wps->skipNoticesAndWarnings(Except::pluginsDirectories('plugin-folder'));
 + $wps->silenceErrorsInPaths('@plugin-folder/vendor@', E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE);
   $wps->run();
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In `wps.php`, call `skipNoticesAndWarnings()` on `$wps` object. So it
 might look like this
 ```diff
   $wps = new \Rarst\wps\Plugin();
-+ $wps->skipNoticesAndWarnings();
++ $wps->skipNoticesAndWarnings(Rarst\wps\Except::blank());
   $wps->run();
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ theme. Pass multiple themes to be excepted as separate arguments.
 + $wps->skipNoticesAndWarnings(new Rarst\wps\Except($excluded_plugins, $excluded_themes));
   $wps->run();
 ``` 
+### Silent Errors using Regex
+By calling `silenceErrorsInPaths` on `$wps` object in `wps.php` file
+before `$wps->run()`, one can define regex paths to silent errors.
+
+While the first parameter of silenceErrorsInPaths accepts regex path,
+the second parameter accepts error levels to silent. Multiple paths can
+be passed through an array.
+
+e.g. If you always want to silence errors coming from vendor directories,
+writing something like below in wps.php will work
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $wps->silenceErrorsInPaths('@/vendor@', E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE);
+  $wps->run();
+```
+Another Example -
+If you want to allow notices/warnings from specific plugin but at the
+same time silent errors that are coming from vendor directory which
+is inside the plugin, then you might write something like this in
+wps.php.
+```diff
+  $wps = new \Rarst\wps\Plugin();
++ $wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('plugin-folder'));
++ $wps->silenceErrorsInPaths('@plugin-folder/vendor@', E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE);
+  $wps->run();
+```
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
 	},
 	"require"    : {
 		"php"                : ">=5.5.9",
-		"composer/installers": "~1.6",
 		"filp/whoops"        : "^2.3.1",
 		"pimple/pimple"      : "^3.2.3"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,140 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e500ce189538c8691f07d5e67ede9ab",
+    "content-hash": "118ab0d32d73e4af77b808cd26b493f8",
     "packages": [
         {
-            "name": "composer/installers",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/installers.git",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
-            },
-            "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Composer\\Installers\\Plugin",
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Installers\\": "src/Composer/Installers"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kyle Robinson Young",
-                    "email": "kyle@dontkry.com",
-                    "homepage": "https://github.com/shama"
-                }
-            ],
-            "description": "A multi-framework Composer library installer",
-            "homepage": "https://composer.github.io/installers/",
-            "keywords": [
-                "Craft",
-                "Dolibarr",
-                "Eliasis",
-                "Hurad",
-                "ImageCMS",
-                "Kanboard",
-                "Lan Management System",
-                "MODX Evo",
-                "Mautic",
-                "Maya",
-                "OXID",
-                "Plentymarkets",
-                "Porto",
-                "RadPHP",
-                "SMF",
-                "Thelia",
-                "WolfCMS",
-                "agl",
-                "aimeos",
-                "annotatecms",
-                "attogram",
-                "bitrix",
-                "cakephp",
-                "chef",
-                "cockpit",
-                "codeigniter",
-                "concrete5",
-                "croogo",
-                "dokuwiki",
-                "drupal",
-                "eZ Platform",
-                "elgg",
-                "expressionengine",
-                "fuelphp",
-                "grav",
-                "installer",
-                "itop",
-                "joomla",
-                "kohana",
-                "laravel",
-                "lavalite",
-                "lithium",
-                "magento",
-                "majima",
-                "mako",
-                "mediawiki",
-                "modulework",
-                "modx",
-                "moodle",
-                "osclass",
-                "phpbb",
-                "piwik",
-                "ppi",
-                "puppet",
-                "pxcms",
-                "reindex",
-                "roundcube",
-                "shopware",
-                "silverstripe",
-                "sydes",
-                "symfony",
-                "typo3",
-                "wordpress",
-                "yawik",
-                "zend",
-                "zikula"
-            ],
-            "time": "2018-08-27T06:10:37+00:00"
-        },
-        {
             "name": "filp/whoops",
-            "version": "2.3.1",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "bc0fd11bc455cc20ee4b5edabc63ebbf859324c7"
+                "reference": "fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/bc0fd11bc455cc20ee4b5edabc63ebbf859324c7",
-                "reference": "bc0fd11bc455cc20ee4b5edabc63ebbf859324c7",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130",
+                "reference": "fff6f1e4f36be0e0d0b84d66b413d9dcb0c49130",
                 "shasum": ""
             },
             "require": {
@@ -146,8 +26,8 @@
             },
             "require-dev": {
                 "mockery/mockery": "^0.9 || ^1.0",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0",
+                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -156,7 +36,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -185,33 +65,33 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2018-10-23T09:00:00+00:00"
+            "time": "2020-01-15T10:00:00+00:00"
         },
         {
             "name": "pimple/pimple",
-            "version": "v3.2.3",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Pimple.git",
-                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+                "reference": "e55d12f9d6a0e7f9c85992b73df1267f46279930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
-                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/e55d12f9d6a0e7f9c85992b73df1267f46279930",
+                "reference": "e55d12f9d6a0e7f9c85992b73df1267f46279930",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": "^7.2.5",
                 "psr/container": "^1.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^3.2"
+                "symfony/phpunit-bridge": "^3.4|^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -230,12 +110,12 @@
                 }
             ],
             "description": "Pimple, a simple Dependency Injection Container",
-            "homepage": "http://pimple.sensiolabs.org",
+            "homepage": "https://pimple.symfony.com",
             "keywords": [
                 "container",
                 "dependency injection"
             ],
-            "time": "2018-01-21T07:42:36+00:00"
+            "time": "2020-03-03T09:12:48+00:00"
         },
         {
             "name": "psr/container",
@@ -288,16 +168,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -306,7 +186,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -331,7 +211,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         }
     ],
     "packages-dev": [],

--- a/php/class-except.php
+++ b/php/class-except.php
@@ -4,33 +4,28 @@ namespace Rarst\wps;
 use InvalidArgumentException;
 
 class Except {
-    public $pluginsDirectories;
-    public $themesDirectories;
+    private $pathPatterns;
 
     /**
-     * Creates Object of Watch Class
+     * Constructor
      *
-     * @param array $pluginsDirectories Names of plugin folders to watch for
-     *                                  Notices & Warnings
-     * @param array $themesDirectories Names of theme folders to watch for
-     *                                 Notices and Warnings
+     * @param  array|string $patterns List or a single regex pattern to match
      */
-    public function __construct($pluginsDirectories = [], $themesDirectories = [])
-    {
-        if(!is_array($pluginsDirectories)) {
-            throw new InvalidArgumentException('$pluginsDirectories should be an array');
-        }
+    public function __construct($pathPatterns) {
+        $pathPatterns = func_get_args();
 
-        if(!is_array($themesDirectories)) {
-            throw new InvalidArgumentException('$themesDirectories should be an array');
+        if(is_array($pathPatterns[0])) {
+            $pathPatterns = $pathPatterns[0];
         }
-
-        $this->pluginsDirectories = $pluginsDirectories;
-        $this->themesDirectories = $themesDirectories;
+        
+        $this->pathPatterns = array_filter($pathPatterns);
     }
 
     /**
-     * Constructor 
+     * Constructor
+     * 
+     * @param array $pluginsDirectories Names of plugin folders to watch for
+     *                                  Notices & Warnings.
      */
     public static function pluginsDirectories($plugins) {
         $plugins = func_get_args();
@@ -39,11 +34,18 @@ class Except {
             throw new InvalidArgumentException('Pass plugins folder names to watch for Notices & Warnings');
         }
 
-        return new self($plugins, []);
+        $plugins = array_map(function($plugin){
+            return '@plugins/' . preg_quote($plugin, '@') . '@';
+        }, $plugins);
+
+        return new self($plugins);
     }
 
     /**
      * Constructor
+     * 
+     * @param array $themesDirectories Names of theme folders to watch for
+     *                                 Notices and Warnings.
      */
     public static function themesDirectories() {
         $themes = func_get_args();
@@ -51,25 +53,26 @@ class Except {
         if(empty($themes)) {
             throw new InvalidArgumentException('Pass themes folder names to watch for Notices & Warnings');
         }
-        return new self([], $themes);
+
+        $themes = array_map(function($theme){
+            return '@themes/' . preg_quote($theme, '@') . '@';
+        }, $themes);
+
+        return new self($themes);
     }
 
     /**
      * Constructor
      */
     public static function blank() {
-        return new self([], []);
+        return new self([]);
     }
 
     public function empty() {
-        return empty($this->pluginsDirectories) && empty($this->themesDirectories);
+        return empty($this->pathPatterns);
     }
 
-    public function emptyPlugins() {
-        return empty($this->pluginsDirectories);
-    }
-
-    public function emptyThemes() {
-        return empty($this->themesDirectories);
+    public function pathPatterns() {
+        return $this->pathPatterns;
     }
 }

--- a/php/class-except.php
+++ b/php/class-except.php
@@ -54,6 +54,13 @@ class Except {
         return new self([], $themes);
     }
 
+    /**
+     * Constructor
+     */
+    public static function blank() {
+        return new self([], []);
+    }
+
     public function empty() {
         return empty($this->pluginsDirectories) && empty($this->themesDirectories);
     }

--- a/php/class-except.php
+++ b/php/class-except.php
@@ -1,0 +1,68 @@
+<?php
+namespace Rarst\wps;
+
+use InvalidArgumentException;
+
+class Except {
+    public $pluginsDirectories;
+    public $themesDirectories;
+
+    /**
+     * Creates Object of Watch Class
+     *
+     * @param array $pluginsDirectories Names of plugin folders to watch for
+     *                                  Notices & Warnings
+     * @param array $themesDirectories Names of theme folders to watch for
+     *                                 Notices and Warnings
+     */
+    public function __construct($pluginsDirectories = [], $themesDirectories = [])
+    {
+        if(!is_array($pluginsDirectories)) {
+            throw new InvalidArgumentException('$pluginsDirectories should be an array');
+        }
+
+        if(!is_array($themesDirectories)) {
+            throw new InvalidArgumentException('$themesDirectories should be an array');
+        }
+
+        $this->pluginsDirectories = $pluginsDirectories;
+        $this->themesDirectories = $themesDirectories;
+    }
+
+    /**
+     * Constructor 
+     */
+    public static function pluginsDirectories($plugins) {
+        $plugins = func_get_args();
+        
+        if(empty($plugins)) {
+            throw new InvalidArgumentException('Pass plugins folder names to watch for Notices & Warnings');
+        }
+
+        return new self($plugins, []);
+    }
+
+    /**
+     * Constructor
+     */
+    public static function themesDirectories() {
+        $themes = func_get_args();
+        
+        if(empty($themes)) {
+            throw new InvalidArgumentException('Pass themes folder names to watch for Notices & Warnings');
+        }
+        return new self([], $themes);
+    }
+
+    public function empty() {
+        return empty($this->pluginsDirectories) && empty($this->themesDirectories);
+    }
+
+    public function emptyPlugins() {
+        return empty($this->pluginsDirectories);
+    }
+
+    public function emptyThemes() {
+        return empty($this->themesDirectories);
+    }
+}

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -103,6 +103,9 @@ class Plugin extends Container {
 		// notices and warnings of whichever theme is active.
 		$defaults['watch_specific_themes'] = [];
 
+		$this['silence_errors_in_paths.pattern'] = null;
+		$this['silence_errors_in_paths.levels'] = 10240; // E_STRICT | E_DEPRECATED.
+
 		$defaults['run'] = function ( $plugin ) {
 			$run = new Whoops_Run_Composite( $plugin['whoops_system_facade'] );
 
@@ -111,6 +114,13 @@ class Plugin extends Container {
 			}
 			$run->watchSpecificPlugins( $plugin['watch_specific_plugins'] );
 			$run->watchSpecificThemes( $plugin['watch_specific_themes'] );
+
+			if( ! is_null( $plugin['silence_errors_in_paths.pattern'] ) ) {
+				$run->silenceErrorsInPaths(
+					$plugin['silence_errors_in_paths.pattern'],
+					$plugin['silence_errors_in_paths.levels']
+				);
+			}
 
 			$run->pushHandler( $plugin['handler.pretty'] );
 			$run->pushHandler( $plugin['handler.json'] );
@@ -163,6 +173,17 @@ class Plugin extends Container {
 		}
 	}
 
+	/**
+     * Silence particular errors in particular files
+     * @param  array|string $patterns List or a single regex pattern to match
+     * @param  int          $levels   Defaults to E_STRICT | E_DEPRECATED
+     * @return \Whoops\Run
+     */
+    public function silenceErrorsInPaths($patterns, $levels = 10240) {
+		$this['silence_errors_in_paths.pattern'] = $patterns;
+		$this['silence_errors_in_paths.levels'] = $levels;
+	}
+	
 	/**
 	 * Execute run conditionally on debug configuration.
 	 */

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -95,13 +95,8 @@ class Plugin extends Container {
 
 		$defaults['skip_all_notices_and_warnings'] = false;
 
-		// Plugins to watch for Notices and Warnings. If blank, then watch for
-		// notices and warnings of all plugins.
-		$defaults['watch_specific_plugins'] = [];
-
-		// Themes to watch for Notices and Warnings. If blank, then watch for
-		// notices and warnings of whichever theme is active.
-		$defaults['watch_specific_themes'] = [];
+		// Files to watch for Notices and Warnings.
+		$defaults['watch_files'] = null;
 
 		$this['silence_errors_in_paths.pattern'] = null;
 		$this['silence_errors_in_paths.levels'] = 10240; // E_STRICT | E_DEPRECATED.
@@ -112,8 +107,10 @@ class Plugin extends Container {
 			if( true === $plugin['skip_all_notices_and_warnings'] ) {
 				$run->skipAllNoticesAndWarnings();
 			}
-			$run->watchSpecificPlugins( $plugin['watch_specific_plugins'] );
-			$run->watchSpecificThemes( $plugin['watch_specific_themes'] );
+
+			if( ! is_null( $plugin['watch_files'] ) ) {
+				$run->watchFilesWithPatterns( $plugin['watch_files'] );
+			}
 
 			if( ! is_null( $plugin['silence_errors_in_paths.pattern'] ) ) {
 				$run->silenceErrorsInPaths(
@@ -155,7 +152,7 @@ class Plugin extends Container {
 	/**
 	 * Skip Notices and Warnings occurring while program execution
 	 *
-	 * @param Except $except Plugins & Themes to be excepted from this privilege.
+	 * @param Except $except Directories to be excepted from this privilege.
 	 * @return void
 	 */
 	public function skipNoticesAndWarnings(Except $except) {
@@ -164,13 +161,7 @@ class Plugin extends Container {
 			return;
 		}
 
-		if( ! $except->emptyPlugins() ) {
-			$this['watch_specific_plugins'] = $except->pluginsDirectories;
-		}
-
-		if( ! $except->emptyThemes() ) {
-			$this['watch_specific_themes'] = $except->themesDirectories;
-		}
+		$this['watch_files'] = $except->pathPatterns();
 	}
 
 	/**
@@ -190,6 +181,11 @@ class Plugin extends Container {
 	public function run() {
 
 		if ( ! $this->is_debug() || ! $this->is_debug_display() ) {
+			add_action('admin_notices', function(){
+				echo '<div class="notice notice-warning is-dismissible">
+						<p><strong>wps</strong> plugin works only when <code>WP_DEBUG</code> & <code>WP_DEBUG_DISPLAY</code> constants are set to <code>true</code></p>
+					</div>';
+			});
 			return;
 		}
 

--- a/php/class-whoops-run-composite.php
+++ b/php/class-whoops-run-composite.php
@@ -67,6 +67,17 @@ class Whoops_Run_Composite {
     }
 
     /**
+     * Silence particular errors in particular files
+     * @param  array|string $patterns List or a single regex pattern to match
+     * @param  int          $levels   Defaults to E_STRICT | E_DEPRECATED
+     * @return Run
+     * @see https://maximivanov.github.io/php-error-reporting-calculator/
+     */
+    public function silenceErrorsInPaths($patterns, $levels = 10240) {
+        $this->run->silenceErrorsInPaths($patterns, $levels);
+    }
+
+    /**
      * Converts generic PHP errors to \ErrorException
      * instances, before passing them off to be handled.
      *

--- a/php/class-whoops-run-composite.php
+++ b/php/class-whoops-run-composite.php
@@ -1,0 +1,135 @@
+<?php
+namespace Rarst\wps;
+
+use Whoops\Exception\ErrorException;
+use Whoops\Exception\Inspector;
+use Whoops\Run;
+use Whoops\Util\SystemFacade;
+
+/**
+ * This class will show Errors and Warnings only if they are coming from
+ * Specific Plugin
+ */
+class Whoops_Run_Composite {
+
+    /**
+     * @var SystemFacade
+     */
+    private $system;
+    
+    /**
+     * @var Run
+     */
+    private $run;
+    
+    private $skipAllNoticesAndWarnings = false;
+
+    private $watchSpecificPlugins = [];
+
+    private $watchSpecificThemes = [];
+
+    public function __construct(SystemFacade $system = null)
+    {
+        $this->system = $system ?: new SystemFacade;
+        $this->run = new Run($this->system);
+    }
+
+    public function register() {
+        class_exists("\\Whoops\\Exception\\ErrorException");
+        class_exists("\\Whoops\\Exception\\FrameCollection");
+        class_exists("\\Whoops\\Exception\\Frame");
+        class_exists("\\Whoops\\Exception\\Inspector");
+
+        $this->system->setErrorHandler([$this, Run::ERROR_HANDLER]);
+        $this->system->setExceptionHandler([$this->run, Run::EXCEPTION_HANDLER]);
+        $this->system->registerShutdownFunction([$this->run, Run::SHUTDOWN_HANDLER]);
+    }
+
+    public function unregister() {
+        $this->system->restoreExceptionHandler();
+        $this->system->restoreErrorHandler();
+    }
+
+    public function pushHandler($handler) {
+        $this->run->pushHandler($handler);
+    }
+
+    public function skipAllNoticesAndWarnings() {
+        $this->skipAllNoticesAndWarnings = true;
+    }
+
+    public function watchSpecificPlugins($plugins) {
+        $this->watchSpecificPlugins = $plugins;
+    }
+
+    public function watchSpecificThemes($themes) {
+        $this->watchSpecificThemes = $themes;
+    }
+
+    /**
+     * Converts generic PHP errors to \ErrorException
+     * instances, before passing them off to be handled.
+     *
+     * This method MUST be compatible with set_error_handler.
+     *
+     * @param int    $level
+     * @param string $message
+     * @param string $file
+     * @param int    $line
+     *
+     * @return bool
+     * @throws ErrorException
+     */
+    public function handleError($level, $message, $file = null, $line = null) {
+
+        // Handle all fatals, exceptions etc.
+        if(in_array(
+            $level, 
+            [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR]
+        )) {
+            $this->run->handleError($level, $message, $file, $line);
+            return false;
+        }
+
+        // If All Notices and Warnings should be skipped, then short-circuit
+        // error handler.
+        if($this->skipAllNoticesAndWarnings) {
+            return false;
+        }
+
+        // Watch for all plugins and Themes
+        if( empty($this->watchSpecificPlugins) && empty($this->watchSpecificThemes ) ) {
+            $this->run->handleError($level, $message, $file, $line);
+            return false;
+        }
+
+        $watchablePlugins = empty($this->watchSpecificPlugins) ? [] : array_map(function($pluginBaseFolder){
+            return 'plugins/' . $pluginBaseFolder;
+        }, $this->watchSpecificPlugins);
+
+        $watchableThemes = empty($this->watchSpecificThemes) ? [] : array_map(function($themeBaseFolder){
+            return 'themes/' . $themeBaseFolder;
+        }, $this->watchSpecificThemes);
+
+        $directoriesToWatchFor = array_merge($watchablePlugins, $watchableThemes);
+        $errorBelongsToWatchCriteria = false;
+        
+        // We are creating an exception object because Inspector Class needs it.
+        $exception = new ErrorException($message, /*code*/ $level, /*severity*/ $level, $file, $line);
+        $frames = (new Inspector($exception))->getFrames();
+        foreach( $frames as $frame ) {
+            foreach($directoriesToWatchFor as $directory) {
+                if (strpos($frame->getFile(), $directory) !== false) {
+                    $errorBelongsToWatchCriteria = true;
+                    break 2;
+                }
+            }
+        }
+
+        if($errorBelongsToWatchCriteria) {
+            $this->run->handleError($level, $message, $file, $line);
+        }
+
+        return false;
+    }
+}

--- a/wps.php
+++ b/wps.php
@@ -36,4 +36,5 @@ if ( isset( $_GET['wps_disable'] ) ) {
 }
 
 $wps = new \Rarst\wps\Plugin();
+$wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('akismet'));
 $wps->run();

--- a/wps.php
+++ b/wps.php
@@ -36,5 +36,4 @@ if ( isset( $_GET['wps_disable'] ) ) {
 }
 
 $wps = new \Rarst\wps\Plugin();
-$wps->skipNoticesAndWarnings(Rarst\wps\Except::pluginsDirectories('akismet'));
 $wps->run();

--- a/wps.php
+++ b/wps.php
@@ -27,6 +27,8 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 DEALINGS IN THE SOFTWARE.
 */
 
+use Rarst\wps\Except;
+
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 }


### PR DESCRIPTION
By default the plugin blocks the execution whenever any kind of
notice/warning/error/exception occurs. This is really useful when
site is being built from the scratch, however, this could create a problem
when everything is not being built from the scratch — specifically when a notice
or warning comes from a plugin you did not develop.

This could be solved in one of the four ways.

### Skip Whoops Blocking for all Notices and Warnings
In `wps.php`, call `skipNoticesAndWarnings()` on `$wps` object. So it
might look like this
```diff
  $wps = new \Rarst\wps\Plugin();
+ $wps->skipNoticesAndWarnings(Except::blank());
  $wps->run();
```

`skipNoticesAndWarnings` accepts an object of `Rarst\wps\Except` class to
enable Whoops for notices/warnings of only specified plugins/themes.

### Enable Whoops' Notices/Warnings Blocking for Specific Plugins
```diff
  $wps = new \Rarst\wps\Plugin();
+ $wps->skipNoticesAndWarnings(Except::pluginsDirectories('akismet'));
  $wps->run();
```
Above example will skip all notices and warnings except coming from `akismet`
plugin. Pass multiple plugins to be excepted as separate arguments.

### Enable Whoops Notices/Warnings Blocking Blocking for Specific Themes
```diff
  $wps = new \Rarst\wps\Plugin();
+ $wps->skipNoticesAndWarnings(Except::themesDirectories('twentytwenty'));
  $wps->run();
```
Above example will skip all notices and warnings except coming from `twentytwenty`
theme. Pass multiple themes to be excepted as separate arguments.

### Enable Whoops Blocking for Specific Plugins and Themes together
```diff
  $wps = new \Rarst\wps\Plugin();
+ $exceptions = ['@plugins/akismet@', '@themes/twentytwenty@'];
+ $wps->skipNoticesAndWarnings(new Except($exceptions));
  $wps->run();
```